### PR TITLE
Openssl1.1

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -36,6 +36,7 @@ if(QTERM_ENABLE_SSH)
       get_filename_component(OPENSSL_CRYPTO_ROOT_DIR ${OPENSSL_CRYPTO_INCLUDE_DIR} PATH)
       set(optionalLibs ${optionalLibs} ${OPENSSL_CRYPTO_LIBRARIES})
       set(optionalSources ${optionalSources}
+      ssh/libcrypto-compat.c
       ssh/auth.cpp
       ssh/channel.cpp
       ssh/crc32.cpp

--- a/src/ssh/auth.cpp
+++ b/src/ssh/auth.cpp
@@ -9,15 +9,15 @@
 // Copyright: See COPYING file that comes with this distribution
 //
 //
+extern "C" {
+#include "libcrypto-compat.h"
+}
 #include "auth.h"
 #include "packet.h"
 #include "ssh1.h"
 #include "ssh2.h"
 #include "hostinfo.h"
 #include <openssl/pem.h>
-#include <openssl/evp.h>
-#include <openssl/rsa.h>
-#include <openssl/dsa.h>
 #include <QtCore/QCryptographicHash>
 #include <QtCore/QDir>
 #include <QtCore/QFile>
@@ -281,10 +281,6 @@ void SSH2Auth::generateSign()
         qDebug("Unknown private key type");
         failureHandler();
         return;
-    }
-    // Copy from libssh
-    if (!EVP_get_cipherbyname("des")) {
-        OPENSSL_init_crypto(0, NULL);
     }
     BIO * mem = BIO_new_mem_buf((void*)privateKeyData.data(), -1);
 

--- a/src/ssh/auth.cpp
+++ b/src/ssh/auth.cpp
@@ -9,6 +9,7 @@
 // Copyright: See COPYING file that comes with this distribution
 //
 //
+#include <openssl/pem.h>
 extern "C" {
 #include "libcrypto-compat.h"
 }
@@ -17,7 +18,6 @@ extern "C" {
 #include "ssh1.h"
 #include "ssh2.h"
 #include "hostinfo.h"
-#include <openssl/pem.h>
 #include <QtCore/QCryptographicHash>
 #include <QtCore/QDir>
 #include <QtCore/QFile>

--- a/src/ssh/auth.cpp
+++ b/src/ssh/auth.cpp
@@ -16,6 +16,8 @@
 #include "hostinfo.h"
 #include <openssl/pem.h>
 #include <openssl/evp.h>
+#include <openssl/rsa.h>
+#include <openssl/dsa.h>
 #include <QtCore/QCryptographicHash>
 #include <QtCore/QDir>
 #include <QtCore/QFile>
@@ -282,7 +284,7 @@ void SSH2Auth::generateSign()
     }
     // Copy from libssh
     if (!EVP_get_cipherbyname("des")) {
-        OpenSSL_add_all_ciphers();
+        OPENSSL_init_crypto(0, NULL);
     }
     BIO * mem = BIO_new_mem_buf((void*)privateKeyData.data(), -1);
 
@@ -327,12 +329,18 @@ void SSH2Auth::generateSign()
         QByteArray buf = QCryptographicHash::hash(tmp.buffer() + m_out->buffer(), QCryptographicHash::Sha1);
         QByteArray sigblob(40, 0);
         sig = DSA_do_sign((uchar*) buf.data(), buf.size(), dsa);
-        rlen = BN_num_bytes(sig->r);
-        slen = BN_num_bytes(sig->s);
+
+        const BIGNUM * r;
+        const BIGNUM * s;
+
+        DSA_SIG_get0(sig, &r, &s);
+
+        rlen = BN_num_bytes(r);
+        slen = BN_num_bytes(s);
 
         //TODO: check rlen and slen: ssh-dss.c in openssh
-        BN_bn2bin(sig->r, (uchar *) sigblob.data() + 20 - rlen);
-        BN_bn2bin(sig->s, (uchar *) sigblob.data() + 40 - slen);
+        BN_bn2bin(r, (uchar *) sigblob.data() + 20 - rlen);
+        BN_bn2bin(s, (uchar *) sigblob.data() + 40 - slen);
         DSA_SIG_free(sig);
         m_out->putUInt32(4 + 7 + 4 + sigblob.size());
         m_out->putString("ssh-dss");

--- a/src/ssh/kex.cpp
+++ b/src/ssh/kex.cpp
@@ -10,6 +10,9 @@
 //
 //
 
+extern "C" {
+#include "libcrypto-compat.h"
+}
 #include "kex.h"
 #include "packet.h"
 #include "transport.h"
@@ -17,8 +20,6 @@
 #include "ssh2.h"
 #include "hostinfo.h"
 #include <openssl/rand.h>
-#include <openssl/dsa.h>
-#include <openssl/rsa.h>
 #include <QtCore/QCryptographicHash>
 
 #ifdef SSH_DEBUG

--- a/src/ssh/kex.cpp
+++ b/src/ssh/kex.cpp
@@ -352,13 +352,18 @@ bool SSH2Kex::verifySignature(const QByteArray & hash, const QByteArray & hostKe
 #endif
     DSA *dsa = DSA_new();
     RSA *rsa = RSA_new();
+    BIGNUM * e = BN_new();
+    BIGNUM * n = BN_new();
+    BIGNUM * p = BN_new();
+    BIGNUM * q = BN_new();
+    BIGNUM * g = BN_new();
+    BIGNUM * pub_key = BN_new();
 
     if (type == "ssh-rsa") {
-        rsa->e = BN_new();
-        rsa->n = BN_new();
-        tmp.getBN(rsa->e);
-        tmp.getBN(rsa->n);
+        tmp.getBN(e);
+        tmp.getBN(n);
         tmp.atEnd();
+        RSA_set0_key(rsa, n, e, NULL);
         qDebug() << "key size: " << RSA_size(rsa);
     }
 
@@ -366,15 +371,13 @@ bool SSH2Kex::verifySignature(const QByteArray & hash, const QByteArray & hostKe
 #ifdef SSH_DEBUG
         qDebug() << "generate DSA key";
 #endif
-        dsa->p = BN_new();
-        dsa->q = BN_new();
-        dsa->g = BN_new();
-        dsa->pub_key = BN_new();
-        tmp.getBN(dsa->p);
-        tmp.getBN(dsa->q);
-        tmp.getBN(dsa->g);
-        tmp.getBN(dsa->pub_key);
+        tmp.getBN(p);
+        tmp.getBN(q);
+        tmp.getBN(g);
+        tmp.getBN(pub_key);
         tmp.atEnd();
+        DSA_set0_pqg(dsa, p, q, g);
+        DSA_set0_key(dsa, pub_key, NULL);
     }
 
     tmp.buffer().append(signature);
@@ -399,12 +402,14 @@ bool SSH2Kex::verifySignature(const QByteArray & hash, const QByteArray & hostKe
 #endif
         DSA_SIG * sig;
         sig = DSA_SIG_new();
-        sig->r = BN_new();
-        sig->s = BN_new();
+        BIGNUM * r = BN_new();
+        BIGNUM * s = BN_new();
 
-        BN_bin2bn((const unsigned char *) signBlob.data(), INTBLOB_LEN, sig->r);
+        BN_bin2bn((const unsigned char *) signBlob.data(), INTBLOB_LEN, r);
 
-        BN_bin2bn((const unsigned char *) signBlob.data() + INTBLOB_LEN, INTBLOB_LEN, sig->s);
+        BN_bin2bn((const unsigned char *) signBlob.data() + INTBLOB_LEN, INTBLOB_LEN, s);
+
+        DSA_SIG_set0(sig, r, s);
 
         QByteArray digest = QCryptographicHash::hash(hash, QCryptographicHash::Sha1);
 
@@ -496,12 +501,13 @@ void SSH1Kex::readKex()
 #endif
 
     RSA * serverKey = RSA_new();
-    serverKey->e = BN_new();
-    serverKey->n = BN_new();
-    m_in->getBN(serverKey->e);
-    m_in->getBN(serverKey->n);
-    QByteArray server_n(BN_num_bytes(serverKey->n), 0);
-    BN_bn2bin(serverKey->n, (unsigned char *) server_n.data());
+    BIGNUM * s_e = BN_new();
+    BIGNUM * s_n = BN_new();
+    m_in->getBN(s_e);
+    m_in->getBN(s_n);
+    RSA_set0_key(serverKey, s_n, s_e, NULL);
+    QByteArray server_n(BN_num_bytes(s_n), 0);
+    BN_bn2bin(s_n, (unsigned char *) server_n.data());
     // TODO: rbits = BN_num_bits(d_servKey->d_rsa->n);
 
     int hostKeyLength = m_in->getUInt32();
@@ -509,12 +515,13 @@ void SSH1Kex::readKex()
     qDebug() << "length" << hostKeyLength;
 #endif
     RSA * hostKey = RSA_new();
-    hostKey->e = BN_new();
-    hostKey->n = BN_new();
-    m_in->getBN(hostKey->e);
-    m_in->getBN(hostKey->n);
-    QByteArray host_n(BN_num_bytes(hostKey->n), 0);
-    BN_bn2bin(hostKey->n, (unsigned char *) host_n.data());
+    BIGNUM * h_e = BN_new();
+    BIGNUM * h_n = BN_new();
+    m_in->getBN(h_e);
+    m_in->getBN(h_n);
+    RSA_set0_key(hostKey, h_n, h_e, NULL);
+    QByteArray host_n(BN_num_bytes(h_n), 0);
+    BN_bn2bin(h_n, (unsigned char *) host_n.data());
     m_sessionID = QCryptographicHash::hash(host_n + server_n + m_cookie, QCryptographicHash::Md5);
 #ifdef SSH_DEBUG
     dumpData(m_sessionID);
@@ -536,7 +543,7 @@ void SSH1Kex::readKex()
         else
             BN_add_word(key, (u_char)m_sessionKey[i]);
     }
-    if (BN_cmp(serverKey->n, hostKey->n) < 0) {
+    if (BN_cmp(s_n, h_n) < 0) {
         publicEncrypt(key, key, serverKey);
         publicEncrypt(key, key, hostKey);
     } else {
@@ -567,10 +574,15 @@ void SSH1Kex::publicEncrypt(BIGNUM *out, BIGNUM *in, RSA *key)
     QByteArray outbuf;
     int len, ilen, olen;
 
-    if (BN_num_bits(key->e) < 2 || !BN_is_odd(key->e))
+    const BIGNUM * e;
+    const BIGNUM * n;
+
+    RSA_get0_key(key, &n, &e, NULL);
+
+    if (BN_num_bits(e) < 2 || !BN_is_odd(e))
         qDebug("rsa_public_encrypt() exponent too small or not odd");
 
-    olen = BN_num_bytes(key->n);
+    olen = BN_num_bytes(n);
     outbuf.resize(olen);
 
     ilen = BN_num_bytes(in);

--- a/src/ssh/libcrypto-compat.c
+++ b/src/ssh/libcrypto-compat.c
@@ -7,9 +7,10 @@
  * https://www.openssl.org/source/license.html
  */
 
+#include "libcrypto-compat.h"
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
 #include <string.h>
 #include <openssl/engine.h>
-#include "libcrypto-compat.h"
 
 static void *OPENSSL_zalloc(size_t num)
 {
@@ -326,3 +327,4 @@ void EVP_CIPHER_CTX_free(EVP_CIPHER_CTX *ctx)
     EVP_CIPHER_CTX_init(ctx);
     OPENSSL_free(ctx);
 }
+#endif /* OPENSSL_VERSION_NUMBER */

--- a/src/ssh/libcrypto-compat.c
+++ b/src/ssh/libcrypto-compat.c
@@ -1,0 +1,328 @@
+/*
+ * Copyright 2016 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the OpenSSL license (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+ */
+
+#include <string.h>
+#include <openssl/engine.h>
+#include "libcrypto-compat.h"
+
+static void *OPENSSL_zalloc(size_t num)
+{
+    void *ret = OPENSSL_malloc(num);
+
+    if (ret != NULL)
+        memset(ret, 0, num);
+    return ret;
+}
+
+int RSA_set0_key(RSA *r, BIGNUM *n, BIGNUM *e, BIGNUM *d)
+{
+    /* If the fields n and e in r are NULL, the corresponding input
+     * parameters MUST be non-NULL for n and e.  d may be
+     * left NULL (in case only the public key is used).
+     */
+    if ((r->n == NULL && n == NULL)
+        || (r->e == NULL && e == NULL))
+        return 0;
+
+    if (n != NULL) {
+        BN_free(r->n);
+        r->n = n;
+    }
+    if (e != NULL) {
+        BN_free(r->e);
+        r->e = e;
+    }
+    if (d != NULL) {
+        BN_free(r->d);
+        r->d = d;
+    }
+
+    return 1;
+}
+
+int RSA_set0_factors(RSA *r, BIGNUM *p, BIGNUM *q)
+{
+    /* If the fields p and q in r are NULL, the corresponding input
+     * parameters MUST be non-NULL.
+     */
+    if ((r->p == NULL && p == NULL)
+        || (r->q == NULL && q == NULL))
+        return 0;
+
+    if (p != NULL) {
+        BN_free(r->p);
+        r->p = p;
+    }
+    if (q != NULL) {
+        BN_free(r->q);
+        r->q = q;
+    }
+
+    return 1;
+}
+
+int RSA_set0_crt_params(RSA *r, BIGNUM *dmp1, BIGNUM *dmq1, BIGNUM *iqmp)
+{
+    /* If the fields dmp1, dmq1 and iqmp in r are NULL, the corresponding input
+     * parameters MUST be non-NULL.
+     */
+    if ((r->dmp1 == NULL && dmp1 == NULL)
+        || (r->dmq1 == NULL && dmq1 == NULL)
+        || (r->iqmp == NULL && iqmp == NULL))
+        return 0;
+
+    if (dmp1 != NULL) {
+        BN_free(r->dmp1);
+        r->dmp1 = dmp1;
+    }
+    if (dmq1 != NULL) {
+        BN_free(r->dmq1);
+        r->dmq1 = dmq1;
+    }
+    if (iqmp != NULL) {
+        BN_free(r->iqmp);
+        r->iqmp = iqmp;
+    }
+
+    return 1;
+}
+
+void RSA_get0_key(const RSA *r,
+                  const BIGNUM **n, const BIGNUM **e, const BIGNUM **d)
+{
+    if (n != NULL)
+        *n = r->n;
+    if (e != NULL)
+        *e = r->e;
+    if (d != NULL)
+        *d = r->d;
+}
+
+void RSA_get0_factors(const RSA *r, const BIGNUM **p, const BIGNUM **q)
+{
+    if (p != NULL)
+        *p = r->p;
+    if (q != NULL)
+        *q = r->q;
+}
+
+void RSA_get0_crt_params(const RSA *r,
+                         const BIGNUM **dmp1, const BIGNUM **dmq1,
+                         const BIGNUM **iqmp)
+{
+    if (dmp1 != NULL)
+        *dmp1 = r->dmp1;
+    if (dmq1 != NULL)
+        *dmq1 = r->dmq1;
+    if (iqmp != NULL)
+        *iqmp = r->iqmp;
+}
+
+void DSA_get0_pqg(const DSA *d,
+                  const BIGNUM **p, const BIGNUM **q, const BIGNUM **g)
+{
+    if (p != NULL)
+        *p = d->p;
+    if (q != NULL)
+        *q = d->q;
+    if (g != NULL)
+        *g = d->g;
+}
+
+int DSA_set0_pqg(DSA *d, BIGNUM *p, BIGNUM *q, BIGNUM *g)
+{
+    /* If the fields p, q and g in d are NULL, the corresponding input
+     * parameters MUST be non-NULL.
+     */
+    if ((d->p == NULL && p == NULL)
+        || (d->q == NULL && q == NULL)
+        || (d->g == NULL && g == NULL))
+        return 0;
+
+    if (p != NULL) {
+        BN_free(d->p);
+        d->p = p;
+    }
+    if (q != NULL) {
+        BN_free(d->q);
+        d->q = q;
+    }
+    if (g != NULL) {
+        BN_free(d->g);
+        d->g = g;
+    }
+
+    return 1;
+}
+
+void DSA_get0_key(const DSA *d,
+                  const BIGNUM **pub_key, const BIGNUM **priv_key)
+{
+    if (pub_key != NULL)
+        *pub_key = d->pub_key;
+    if (priv_key != NULL)
+        *priv_key = d->priv_key;
+}
+
+int DSA_set0_key(DSA *d, BIGNUM *pub_key, BIGNUM *priv_key)
+{
+    /* If the field pub_key in d is NULL, the corresponding input
+     * parameters MUST be non-NULL.  The priv_key field may
+     * be left NULL.
+     */
+    if (d->pub_key == NULL && pub_key == NULL)
+        return 0;
+
+    if (pub_key != NULL) {
+        BN_free(d->pub_key);
+        d->pub_key = pub_key;
+    }
+    if (priv_key != NULL) {
+        BN_free(d->priv_key);
+        d->priv_key = priv_key;
+    }
+
+    return 1;
+}
+
+void DSA_SIG_get0(const DSA_SIG *sig, const BIGNUM **pr, const BIGNUM **ps)
+{
+    if (pr != NULL)
+        *pr = sig->r;
+    if (ps != NULL)
+        *ps = sig->s;
+}
+
+int DSA_SIG_set0(DSA_SIG *sig, BIGNUM *r, BIGNUM *s)
+{
+    if (r == NULL || s == NULL)
+        return 0;
+    BN_clear_free(sig->r);
+    BN_clear_free(sig->s);
+    sig->r = r;
+    sig->s = s;
+    return 1;
+}
+
+void ECDSA_SIG_get0(const ECDSA_SIG *sig, const BIGNUM **pr, const BIGNUM **ps)
+{
+    if (pr != NULL)
+        *pr = sig->r;
+    if (ps != NULL)
+        *ps = sig->s;
+}
+
+int ECDSA_SIG_set0(ECDSA_SIG *sig, BIGNUM *r, BIGNUM *s)
+{
+    if (r == NULL || s == NULL)
+        return 0;
+    BN_clear_free(sig->r);
+    BN_clear_free(sig->s);
+    sig->r = r;
+    sig->s = s;
+    return 1;
+}
+
+EVP_MD_CTX *EVP_MD_CTX_new(void)
+{
+    return OPENSSL_zalloc(sizeof(EVP_MD_CTX));
+}
+
+static void OPENSSL_clear_free(void *str, size_t num)
+{
+    if (str == NULL)
+        return;
+    if (num)
+        OPENSSL_cleanse(str, num);
+    OPENSSL_free(str);
+}
+
+/* This call frees resources associated with the context */
+int EVP_MD_CTX_reset(EVP_MD_CTX *ctx)
+{
+    if (ctx == NULL)
+        return 1;
+
+    /*
+     * Don't assume ctx->md_data was cleaned in EVP_Digest_Final, because
+     * sometimes only copies of the context are ever finalised.
+     */
+    if (ctx->digest && ctx->digest->cleanup
+        && !EVP_MD_CTX_test_flags(ctx, EVP_MD_CTX_FLAG_CLEANED))
+        ctx->digest->cleanup(ctx);
+    if (ctx->digest && ctx->digest->ctx_size && ctx->md_data
+        && !EVP_MD_CTX_test_flags(ctx, EVP_MD_CTX_FLAG_REUSE)) {
+        OPENSSL_clear_free(ctx->md_data, ctx->digest->ctx_size);
+    }
+    EVP_PKEY_CTX_free(ctx->pctx);
+#ifndef OPENSSL_NO_ENGINE
+    ENGINE_finish(ctx->engine);
+#endif
+    OPENSSL_cleanse(ctx, sizeof(*ctx));
+
+    return 1;
+}
+
+void EVP_MD_CTX_free(EVP_MD_CTX *ctx)
+{
+    EVP_MD_CTX_reset(ctx);
+    OPENSSL_free(ctx);
+}
+
+HMAC_CTX *HMAC_CTX_new(void)
+{
+    HMAC_CTX *ctx = OPENSSL_zalloc(sizeof(HMAC_CTX));
+
+    if (ctx != NULL) {
+        if (!HMAC_CTX_reset(ctx)) {
+            HMAC_CTX_free(ctx);
+            return NULL;
+        }
+    }
+    return ctx;
+}
+
+static void hmac_ctx_cleanup(HMAC_CTX *ctx)
+{
+    EVP_MD_CTX_reset(&ctx->i_ctx);
+    EVP_MD_CTX_reset(&ctx->o_ctx);
+    EVP_MD_CTX_reset(&ctx->md_ctx);
+    ctx->md = NULL;
+    ctx->key_length = 0;
+    OPENSSL_cleanse(ctx->key, sizeof(ctx->key));
+}
+
+void HMAC_CTX_free(HMAC_CTX *ctx)
+{
+    if (ctx != NULL) {
+        hmac_ctx_cleanup(ctx);
+        EVP_MD_CTX_free(&ctx->i_ctx);
+        EVP_MD_CTX_free(&ctx->o_ctx);
+        EVP_MD_CTX_free(&ctx->md_ctx);
+        OPENSSL_free(ctx);
+    }
+}
+
+int HMAC_CTX_reset(HMAC_CTX *ctx)
+{
+    HMAC_CTX_init(ctx);
+    return 1;
+}
+
+EVP_CIPHER_CTX *EVP_CIPHER_CTX_new(void)
+{
+    return OPENSSL_zalloc(sizeof(EVP_CIPHER_CTX));
+}
+
+void EVP_CIPHER_CTX_free(EVP_CIPHER_CTX *ctx)
+{
+    /* EVP_CIPHER_CTX_reset(ctx); alias */
+    EVP_CIPHER_CTX_init(ctx);
+    OPENSSL_free(ctx);
+}

--- a/src/ssh/libcrypto-compat.h
+++ b/src/ssh/libcrypto-compat.h
@@ -1,0 +1,42 @@
+#ifndef LIBCRYPTO_COMPAT_H
+#define LIBCRYPTO_COMPAT_H
+
+#include <openssl/opensslv.h>
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+
+#include <openssl/rsa.h>
+#include <openssl/dsa.h>
+#include <openssl/ecdsa.h>
+#include <openssl/dh.h>
+#include <openssl/evp.h>
+#include <openssl/hmac.h>
+
+int RSA_set0_key(RSA *r, BIGNUM *n, BIGNUM *e, BIGNUM *d);
+int RSA_set0_factors(RSA *r, BIGNUM *p, BIGNUM *q);
+int RSA_set0_crt_params(RSA *r, BIGNUM *dmp1, BIGNUM *dmq1, BIGNUM *iqmp);
+void RSA_get0_key(const RSA *r, const BIGNUM **n, const BIGNUM **e, const BIGNUM **d);
+void RSA_get0_factors(const RSA *r, const BIGNUM **p, const BIGNUM **q);
+void RSA_get0_crt_params(const RSA *r, const BIGNUM **dmp1, const BIGNUM **dmq1, const BIGNUM **iqmp);
+
+void DSA_get0_pqg(const DSA *d, const BIGNUM **p, const BIGNUM **q, const BIGNUM **g);
+int DSA_set0_pqg(DSA *d, BIGNUM *p, BIGNUM *q, BIGNUM *g);
+void DSA_get0_key(const DSA *d, const BIGNUM **pub_key, const BIGNUM **priv_key);
+int DSA_set0_key(DSA *d, BIGNUM *pub_key, BIGNUM *priv_key);
+
+void DSA_SIG_get0(const DSA_SIG *sig, const BIGNUM **pr, const BIGNUM **ps);
+int DSA_SIG_set0(DSA_SIG *sig, BIGNUM *r, BIGNUM *s);
+
+void ECDSA_SIG_get0(const ECDSA_SIG *sig, const BIGNUM **pr, const BIGNUM **ps);
+int ECDSA_SIG_set0(ECDSA_SIG *sig, BIGNUM *r, BIGNUM *s);
+
+int EVP_MD_CTX_reset(EVP_MD_CTX *ctx);
+EVP_MD_CTX *EVP_MD_CTX_new(void);
+void EVP_MD_CTX_free(EVP_MD_CTX *ctx);
+
+HMAC_CTX *HMAC_CTX_new(void);
+int HMAC_CTX_reset(HMAC_CTX *ctx);
+void HMAC_CTX_free(HMAC_CTX *ctx);
+
+#endif /* OPENSSL_VERSION_NUMBER */
+
+#endif /* LIBCRYPTO_COMPAT_H */

--- a/src/ssh/libcrypto-compat.h
+++ b/src/ssh/libcrypto-compat.h
@@ -2,14 +2,14 @@
 #define LIBCRYPTO_COMPAT_H
 
 #include <openssl/opensslv.h>
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
-
 #include <openssl/rsa.h>
 #include <openssl/dsa.h>
 #include <openssl/ecdsa.h>
 #include <openssl/dh.h>
 #include <openssl/evp.h>
 #include <openssl/hmac.h>
+
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
 
 int RSA_set0_key(RSA *r, BIGNUM *n, BIGNUM *e, BIGNUM *d);
 int RSA_set0_factors(RSA *r, BIGNUM *p, BIGNUM *q);

--- a/src/ssh/packet.cpp
+++ b/src/ssh/packet.cpp
@@ -451,7 +451,7 @@ void SSH2OutBuffer::putBN(const BIGNUM * value)
         return;
     }
 
-    if (value->neg) {
+    if (BN_is_negative(value)) {
         qDebug("putBN: negative numbers not supported");
         return;
     }

--- a/src/ssh/transport.cpp
+++ b/src/ssh/transport.cpp
@@ -9,6 +9,9 @@
 // Copyright: See COPYING file that comes with this distribution
 //
 //
+extern "C" {
+#include "libcrypto-compat.h"
+}
 #include "transport.h"
 #include <QtCore/QString>
 

--- a/src/ssh/transport.cpp
+++ b/src/ssh/transport.cpp
@@ -121,8 +121,7 @@ QByteArray SSH2Encryption::crypt(const QByteArray & src)
 
 SSH2MAC::SSH2MAC(const QString & algorithm)
 {
-    m_ctx = (HMAC_CTX*) malloc(sizeof(HMAC_CTX));
-    HMAC_CTX_init(m_ctx);
+    m_ctx = HMAC_CTX_new();
     if (algorithm == "hmac-sha1") {
         m_keyLen = 20;
         m_macLen = 20;
@@ -136,13 +135,12 @@ SSH2MAC::SSH2MAC(const QString & algorithm)
 
 SSH2MAC::~SSH2MAC()
 {
-    HMAC_CTX_cleanup(m_ctx);
-    free(m_ctx);
+    HMAC_CTX_free(m_ctx);
 }
 QByteArray SSH2MAC::mac(const QByteArray & data)
 {
     QByteArray hmac(m_macLen, 0);
-    HMAC_Init(m_ctx, (const uint8_t*) m_key.data(), m_keyLen, m_evptype);
+    HMAC_Init_ex(m_ctx, (const uint8_t*) m_key.data(), m_keyLen, m_evptype, NULL);
     HMAC_Update(m_ctx, (const uint8_t *) data.data(), data.size());
     HMAC_Final(m_ctx, (uint8_t *) hmac.data(), NULL);
     return hmac;


### PR DESCRIPTION
This set of patches should make QTerm compatible with OpenSSL 1.0 and 1.1. Did not actually tested it in runtime with OpenSSL 1.1 library. I included a libcrypto-compat.c that seems come from the openssl wiki. Rumor has it that openssl might include it in the official 1.0 codebase in the future as a forward compatible layer. @xiaoqiangwang could you test if this works with 1.1?