### PR TITLE
Use Travis and Appveyor to deploy binarys for OSX and Windows

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -61,8 +61,8 @@ install:
  - if not %QTDIR:msvc=%==%QTDIR% %make% /? > nul
 
 build_script:
- - mkdir build
- - cd build
- - cmake "%APPVEYOR_BUILD_FOLDER%" -G "%CMAKE_GENERATOR%" -DQTERM_ENABLE_SCRIPT_DEBUGGER=On -DQT5=Yes
+ - mkdir %APPVEYOR_BUILD_FOLDER%
+ - cd %APPVEYOR_BUILD_FOLDER%
+ - cmake . -G "%CMAKE_GENERATOR%" -DQTERM_ENABLE_SCRIPT_DEBUGGER=On -DQT5=Yes
  - '%make% VERBOSE=1'
  - if not %QTDIR:msvc=%==%QTDIR% %make% package

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -61,7 +61,6 @@ install:
  - if not %QTDIR:msvc=%==%QTDIR% %make% /? > nul
 
 build_script:
- - mkdir %APPVEYOR_BUILD_FOLDER%
  - cd %APPVEYOR_BUILD_FOLDER%
  - cmake . -G "%CMAKE_GENERATOR%" -DQTERM_ENABLE_SCRIPT_DEBUGGER=On -DQT5=Yes
  - '%make% VERBOSE=1'

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -62,7 +62,7 @@ install:
 
 build_script:
  - cd %APPVEYOR_BUILD_FOLDER%
- - cmake . -G "%CMAKE_GENERATOR%" -DQTERM_ENABLE_SCRIPT_DEBUGGER=On -DQT5=Yes
+ - cmake . -G "%CMAKE_GENERATOR%" -DQTERM_ENABLE_SCRIPT_DEBUGGER=On -DCMAKE_BUILD_TYPE=Release -DQT5=Yes
  - '%make% VERBOSE=1'
  - if not %QTDIR:msvc=%==%QTDIR% %make% package
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -66,3 +66,25 @@ build_script:
  - cmake . -G "%CMAKE_GENERATOR%" -DQTERM_ENABLE_SCRIPT_DEBUGGER=On -DQT5=Yes
  - '%make% VERBOSE=1'
  - if not %QTDIR:msvc=%==%QTDIR% %make% package
+
+artifacts:
+ - path: QTerm*-win64.exe
+   name: Win64Installer
+ - path: QTerm*-win32.exe
+   name: Win32Installer
+
+deploy:
+  - provider: GitHub
+    artifact: Win64Installer
+    auth_token:
+      secure: wc0cFfZSLHWbW3W8FKqgVPHQfF0bV1l54wkpLcpsq4EuBliQdwfV+4JLnWuHBdr4
+    on:
+      appveyor_repo_tag: true
+      QTDIR: C:\Qt\5.7\msvc2015_64
+  - provider: GitHub
+    artifact: Win32Installer
+    auth_token:
+      secure: wc0cFfZSLHWbW3W8FKqgVPHQfF0bV1l54wkpLcpsq4EuBliQdwfV+4JLnWuHBdr4
+    on:
+      appveyor_repo_tag: true
+      QTDIR: C:\Qt\5.7\msvc2015

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,8 +46,8 @@ script:
  - '[[ "$TRAVIS_OS_NAME" != linux || "$PPA" == */opt-* ]] || export QT_SELECT=qt5'
  - mkdir -p "$TRAVIS_BUILD_DIR-build"
  - pushd "$TRAVIS_BUILD_DIR-build"
- - '[ "$TRAVIS_OS_NAME" != osx ] || cmake $TRAVIS_BUILD_DIR -DCMAKE_PREFIX_PATH=`brew --prefix qt$BREW` -DQTERM_ENABLE_SCRIPT_DEBUGGER=On -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl -DQT5=Yes'
- - '[ "$TRAVIS_OS_NAME" != linux ] || cmake $TRAVIS_BUILD_DIR -DQTERM_ENABLE_SCRIPT_DEBUGGER=On -DQT5=Yes'
+ - '[ "$TRAVIS_OS_NAME" != osx ] || cmake $TRAVIS_BUILD_DIR -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=`brew --prefix qt$BREW` -DQTERM_ENABLE_SCRIPT_DEBUGGER=On -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl -DQT5=Yes'
+ - '[ "$TRAVIS_OS_NAME" != linux ] || cmake $TRAVIS_BUILD_DIR -DCMAKE_BUILD_TYPE=Release -DQTERM_ENABLE_SCRIPT_DEBUGGER=On -DQT5=Yes'
  - make VERBOSE=1
  - '[ "$TRAVIS_OS_NAME" != osx ] || make package'
  - popd

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,10 +44,10 @@ install:
 script:
  - '[[ "$TRAVIS_OS_NAME" != linux || "$PPA" != */opt-* ]] || . /opt/qt$QT/bin/qt$QT-env.sh'
  - '[[ "$TRAVIS_OS_NAME" != linux || "$PPA" == */opt-* ]] || export QT_SELECT=qt5'
- - mkdir build
- - pushd build
- - '[ "$TRAVIS_OS_NAME" != osx ] || cmake .. -DCMAKE_PREFIX_PATH=`brew --prefix qt$BREW` -DQTERM_ENABLE_SCRIPT_DEBUGGER=On -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl -DQT5=Yes'
- - '[ "$TRAVIS_OS_NAME" != linux ] || cmake .. -DQTERM_ENABLE_SCRIPT_DEBUGGER=On -DQT5=Yes'
+ - mkdir -p "$TRAVIS_BUILD_DIR-build"
+ - pushd "$TRAVIS_BUILD_DIR-build"
+ - '[ "$TRAVIS_OS_NAME" != osx ] || cmake $TRAVIS_BUILD_DIR -DCMAKE_PREFIX_PATH=`brew --prefix qt$BREW` -DQTERM_ENABLE_SCRIPT_DEBUGGER=On -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl -DQT5=Yes'
+ - '[ "$TRAVIS_OS_NAME" != linux ] || cmake $TRAVIS_BUILD_DIR -DQTERM_ENABLE_SCRIPT_DEBUGGER=On -DQT5=Yes'
  - make VERBOSE=1
  - '[ "$TRAVIS_OS_NAME" != osx ] || make package'
  - popd

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,3 +51,11 @@ script:
  - make VERBOSE=1
  - '[ "$TRAVIS_OS_NAME" != osx ] || make package'
  - popd
+
+deploy:
+  provider: releases
+  api_key:
+    secure: qDCCl44gzldjuYBb+HZXqQLvBOVvpiRQxjnaEr5dtGHY2V3D0EXVJrxJBApobMSIqdQBg/SYVJBV9piahricc0ObbWScN/gNyn7gIclmhui80Sk/aL7uBquGiPK/WCZmRwP688OhTbHkzQ/Mo5rrhoR396tYMfi42SXxaENQauJOtP3ZSewrBBGqRmOLzbZw7rSihcBgXPp6wntJvcVdNrKfYp+S1cTYFNGniwUAso25I6rR7BUU/7CtKHOeST2EXFYR6YBX35Yz2Pyf8+QfXVIYwaNs5lGy113MeW3gXxxtUdlto2G41uDHZZGFsm3+2hz2WbtR5DUySgKdjlXrMGM5+ES4fydJ6ylt+BiAnU40rgiPB7KXnz0nAYE3kPA9oNy7HCBkwSoygoGu+AG1HSq5yXuMy4wbAaHy8abAyRv07jNZHwX2wu99j2qikVa/xbqmv3MmVrjuCbsMidjBZmjkUTYOI2oacwhjuIqru8VPMDs7DuSjWtP7qQGm3vAUDd4jnCTpV8m6VDZrLC9UuJQ/Ex0BCufKokLWhdaF5crwQIUIUivMTuAxKVwkclT5RxM/NCRl7bbiob2Kd+TqafD08kUOruXhpF1I8QKeRNHfFPdaoG4j6CD920IjgJAptpO3Pz8+q2+CNWhqYTHGhurcnn92W0w+aI0D8qt3dho=
+  file: QTerm-0.7.1-Darwin.dmg
+  on:
+    repo: hephooey/qterm

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,9 @@ deploy:
   provider: releases
   api_key:
     secure: qDCCl44gzldjuYBb+HZXqQLvBOVvpiRQxjnaEr5dtGHY2V3D0EXVJrxJBApobMSIqdQBg/SYVJBV9piahricc0ObbWScN/gNyn7gIclmhui80Sk/aL7uBquGiPK/WCZmRwP688OhTbHkzQ/Mo5rrhoR396tYMfi42SXxaENQauJOtP3ZSewrBBGqRmOLzbZw7rSihcBgXPp6wntJvcVdNrKfYp+S1cTYFNGniwUAso25I6rR7BUU/7CtKHOeST2EXFYR6YBX35Yz2Pyf8+QfXVIYwaNs5lGy113MeW3gXxxtUdlto2G41uDHZZGFsm3+2hz2WbtR5DUySgKdjlXrMGM5+ES4fydJ6ylt+BiAnU40rgiPB7KXnz0nAYE3kPA9oNy7HCBkwSoygoGu+AG1HSq5yXuMy4wbAaHy8abAyRv07jNZHwX2wu99j2qikVa/xbqmv3MmVrjuCbsMidjBZmjkUTYOI2oacwhjuIqru8VPMDs7DuSjWtP7qQGm3vAUDd4jnCTpV8m6VDZrLC9UuJQ/Ex0BCufKokLWhdaF5crwQIUIUivMTuAxKVwkclT5RxM/NCRl7bbiob2Kd+TqafD08kUOruXhpF1I8QKeRNHfFPdaoG4j6CD920IjgJAptpO3Pz8+q2+CNWhqYTHGhurcnn92W0w+aI0D8qt3dho=
-  file: QTerm-0.7.1-Darwin.dmg
+  file_glob: true
+  file: $TRAVIS_BUILD_DIR-build/QTerm-*-Darwin.dmg
   on:
     repo: hephooey/qterm
+    condition: '"$TRAVIS_OS_NAME" == osx && "$CXX" == clang++ && "$QT" == 56'
+    tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,5 @@ deploy:
   file_glob: true
   file: $TRAVIS_BUILD_DIR-build/QTerm-*-Darwin.dmg
   on:
-    repo: hephooey/qterm
     condition: '"$TRAVIS_OS_NAME" == osx && "$CXX" == clang++ && "$QT" == 56'
     tags: true


### PR DESCRIPTION
The updated ymls should automatically upload binaries generated by make package when the commit is tagged. For now OSX binary uses clang and Qt 5.6. Windows ones use VS 2015 and Qt 5.7. 